### PR TITLE
【サーバサイド】商品詳細表示

### DIFF
--- a/app/assets/javascripts/item_show.js
+++ b/app/assets/javascripts/item_show.js
@@ -1,10 +1,10 @@
 
-$(function(){
-  $(".item-box-image__thumbnail").first().addClass("active");
-  $(".item-box-image__thumbnail").mouseover(function () {
-    image_url = $(this).attr("src");
-    $(".item-box-image__main").attr("src", image_url).hide().fadeIn();
-    $(".item-box-image__thumbnail").removeClass("active");
-    $(this).addClass("active");
-  });
-});
+// $(function(){
+//   $(".item-box-image__thumbnail").first().addClass("active");
+//   $(".item-box-image__thumbnail").mouseover(function () {
+//     image_url = $(this).attr("src");
+//     $(".item-box-image__main").attr("src", image_url).hide().fadeIn();
+//     $(".item-box-image__thumbnail").removeClass("active");
+//     $(this).addClass("active");
+//   });
+// });

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :set_item, only: [:show, :destroy]
+  # before_action :set_item, only: [:show, :destroy]
 
   def index
     @items = Item.where(sold_day: nil).includes(:images).order(updated_at: "DESC")
@@ -45,8 +45,8 @@ class ItemsController < ApplicationController
     end
   end
 
-  def show
-  end
+  # def show
+  # end
 
   def edit
   end
@@ -65,9 +65,9 @@ class ItemsController < ApplicationController
       images_attributes: [:image, :_destroy, :id]).merge(user_id: current_user.id)
   end
   
-  def set_item
-    @item = Item.find(params[:id])
-  end
+  # def set_item
+  #   @item = Item.find(params[:id])
+  # end
 
 end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -18,12 +18,12 @@ class Item < ApplicationRecord
   validates :images, presence: {message: "を選択してください"}
   accepts_nested_attributes_for :images, allow_destroy: true
 
-  def previous
-    Item.where("id < ?", self.id).order("id DESC").first
-  end
+  # def previous
+  #   Item.where("id < ?", self.id).order("id DESC").first
+  # end
 
-  def next
-    Item.where("id > ?", self.id).order("id ASC").first
-  end
+  # def next
+  #   Item.where("id > ?", self.id).order("id ASC").first
+  # end
 
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,125 +1,125 @@
-= render 'index_header'
+-# = render 'index_header'
 
-.main
-  .item-contents
-    .item-box
-      %h2.item-box__name
-        = @item.name
-      .item-box-image
-        - if @item.sold_day != nil
-          .item-box-image__sold-mark
-            .item-box-image__sold-mark--text
-              SOLD
-        - else
-        .item-box-image__main-image-box
-          = image_tag "#{@item.images[0].image}", class: "item-box-image__main"
-        %ul
-          - @item.images.each.with_index do |image|
-            = image_tag "#{image.image}", class: "item-box-image__thumbnail"
-      .item-box__price
-        = "#{@item.price.to_s(:delimited)}円"
-        %span (税込)
-        %span.item-box__price--detail
-          = "#{@item.shipping_fee.name}"
-      - if @item.sold_day == nil
-        - if user_signed_in?
-          - if @item.user.id == current_user.id
-            = link_to edit_item_path(@item), class:'item-box__item-change-btn' do
-              商品の編集
-            %p or
-            %a#modal-open.item-box__item-delete-btn この商品を削除する
-          - else 
-            =link_to item_index_path(@item), class:'item-box__order-btn' do
-              購入画面に進む
-      -else
-        %p.item-box__sold-tag 売り切れました
-      .item-box__item-detail
-        = @item.explanation
-      .table
-        %table
-          %tr
-            %th 出品者
-            %td
-              = User.find(@item.user_id).nickname
-          %tr
-            %th カテゴリー
-            %td
-              %a.category1
-                = @item.category.parent.parent.name
-              %br
-              %a.category2
-                = @item.category.parent.name
-              %br
-              %a.category3
-                = @item.category.name
-          %tr
-            %th ブランド
-            %td 
-              -if @item.brand?
-                =@item.brand
-          %tr
-            %th 商品のサイズ
-            %td 
-              - if @item.item_size_id?
-                = @item.item_size.size
+-# .main
+-#   .item-contents
+-#     .item-box
+-#       %h2.item-box__name
+-#         = @item.name
+-#       .item-box-image
+-#         - if @item.sold_day != nil
+-#           .item-box-image__sold-mark
+-#             .item-box-image__sold-mark--text
+-#               SOLD
+-#         - else
+-#         .item-box-image__main-image-box
+-#           = image_tag "#{@item.images[0].image}", class: "item-box-image__main"
+-#         %ul
+-#           - @item.images.each.with_index do |image|
+-#             = image_tag "#{image.image}", class: "item-box-image__thumbnail"
+-#       .item-box__price
+-#         = "#{@item.price.to_s(:delimited)}円"
+-#         %span (税込)
+-#         %span.item-box__price--detail
+-#           = "#{@item.shipping_fee.name}"
+-#       - if @item.sold_day == nil
+-#         - if user_signed_in?
+-#           - if @item.user.id == current_user.id
+-#             = link_to edit_item_path(@item), class:'item-box__item-change-btn' do
+-#               商品の編集
+-#             %p or
+-#             %a#modal-open.item-box__item-delete-btn この商品を削除する
+-#           - else 
+-#             =link_to item_index_path(@item), class:'item-box__order-btn' do
+-#               購入画面に進む
+-#       -else
+-#         %p.item-box__sold-tag 売り切れました
+-#       .item-box__item-detail
+-#         = @item.explanation
+-#       .table
+-#         %table
+-#           %tr
+-#             %th 出品者
+-#             %td
+-#               = User.find(@item.user_id).nickname
+-#           %tr
+-#             %th カテゴリー
+-#             %td
+-#               %a.category1
+-#                 = @item.category.parent.parent.name
+-#               %br
+-#               %a.category2
+-#                 = @item.category.parent.name
+-#               %br
+-#               %a.category3
+-#                 = @item.category.name
+-#           %tr
+-#             %th ブランド
+-#             %td 
+-#               -if @item.brand?
+-#                 =@item.brand
+-#           %tr
+-#             %th 商品のサイズ
+-#             %td 
+-#               - if @item.item_size_id?
+-#                 = @item.item_size.size
 
-          %tr
-            %th 商品の状態
-            %td 
-              = @item.condition.name
-          %tr
-            %th 配送料の負担
-            %td
-              = @item.shipping_fee.name
-          %tr
-            %th 発送元の地域
-            %td
-              = @item.prefecture.name
-          %tr
-            %th 発送日の目安
-            %td
-              = @item.shipping_day.name
-      .item-box__option-area
-        .item-box__option-area--like-btn
-          %i.fa.fa-star
-          お気に入り 0
-        %a.item-box__option-area--optional-btn
-          %i.fa.fa-flag
-          不適切な商品情報
+-#           %tr
+-#             %th 商品の状態
+-#             %td 
+-#               = @item.condition.name
+-#           %tr
+-#             %th 配送料の負担
+-#             %td
+-#               = @item.shipping_fee.name
+-#           %tr
+-#             %th 発送元の地域
+-#             %td
+-#               = @item.prefecture.name
+-#           %tr
+-#             %th 発送日の目安
+-#             %td
+-#               = @item.shipping_day.name
+-#       .item-box__option-area
+-#         .item-box__option-area--like-btn
+-#           %i.fa.fa-star
+-#           お気に入り 0
+-#         %a.item-box__option-area--optional-btn
+-#           %i.fa.fa-flag
+-#           不適切な商品情報
 
-    .comment-box
-      = form_with(link_to: '#', local: true, method: :get, class: "comment-form") do |form|
-        = form.text_area :'#', class: "comment-input"
-        %p.notice 
-          相手のことを考え丁寧なコメントを心がけましょう。
-          %br
-          不快な言葉遣いなどは利用制限や退会処分となることがあります。
-        %br
-        = button_tag type: 'submit', class: 'comment-btn' do
-          %i.fa.fa-comment コメントする
+-#     .comment-box
+-#       = form_with(link_to: '#', local: true, method: :get, class: "comment-form") do |form|
+-#         = form.text_area :'#', class: "comment-input"
+-#         %p.notice 
+-#           相手のことを考え丁寧なコメントを心がけましょう。
+-#           %br
+-#           不快な言葉遣いなどは利用制限や退会処分となることがあります。
+-#         %br
+-#         = button_tag type: 'submit', class: 'comment-btn' do
+-#           %i.fa.fa-comment コメントする
 
-    %ul.nav-item-link.clreafix
-      - if @item.previous.present? 
-        = link_to item_path(@item.previous), class: "nav-item-prev" do
-          %i.fa.fa-angle-left
-          前の商品
-      - if @item.next.present? 
-        = link_to item_path(@item.next), class: "nav-item-next" do
-          後ろの商品
-          %i.fa.fa-angle-right
+-#     %ul.nav-item-link.clreafix
+-#       - if @item.previous.present? 
+-#         = link_to item_path(@item.previous), class: "nav-item-prev" do
+-#           %i.fa.fa-angle-left
+-#           前の商品
+-#       - if @item.next.present? 
+-#         = link_to item_path(@item.next), class: "nav-item-next" do
+-#           後ろの商品
+-#           %i.fa.fa-angle-right
 
-    .relayted-items
-      = link_to "#{@item.category.parent.parent.name}をもっと見る", '#'
+-#     .relayted-items
+-#       = link_to "#{@item.category.parent.parent.name}をもっと見る", '#'
 
-%aside#modal-content
-  %span.modal-tilte 確認
-  %p 削除すると二度と復活できません。
-  %p 本当に削除しますか？
-  .modal-content__footer
-    %a#modal-close.button-link キャンセル
-    = link_to item_path(@item), method: :delete, class: "button-link", id: "modal-close" do
-      削除
+-# %aside#modal-content
+-#   %span.modal-tilte 確認
+-#   %p 削除すると二度と復活できません。
+-#   %p 本当に削除しますか？
+-#   .modal-content__footer
+-#     %a#modal-close.button-link キャンセル
+-#     = link_to item_path(@item), method: :delete, class: "button-link", id: "modal-close" do
+-#       削除
 
-= render 'index_app-banner'
-= render 'index_footer'
+-# = render 'index_app-banner'
+-# = render 'index_footer'
 


### PR DESCRIPTION
# what
商品の詳細を確認することができるようにする。

# why
・商品出品時に登録した情報が見られるようになっている
・ログアウト状態でも商品詳細ページを見ることができる
・出品者にしか商品の情報編集・削除のリンクが踏めないようになっている
・出品者以外にしか商品購入のリンクが踏めないようになっている


# ブランチをマスターにマージしてしまったため編集箇所をコメントアウトしてプルリクエストに編集箇所を表示するようにしております