### PR TITLE
購入機能0523_new

### DIFF
--- a/app/controllers/card_controller.rb
+++ b/app/controllers/card_controller.rb
@@ -1,0 +1,53 @@
+class CardController < ApplicationController
+
+  require "payjp"
+
+  def new
+    card = Card.where(user_id: current_user.id)
+    redirect_to action: "show" if card.exists?
+  end
+
+  def pay 
+    Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+    if params['payjp-token'].blank?
+      redirect_to action: "new"
+    else
+      customer = Payjp::Customer.create(
+      description: '登録テスト',
+      email: current_user.email, 
+      card: params['payjp-token'],
+      metadata: {user_id: current_user.id}
+      ) 
+      @card = Card.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
+      if @card.save
+        redirect_to action: "show"
+      else
+        redirect_to action: "pay"
+      end
+    end
+  end
+
+  def delete
+    card = Card.where(user_id: current_user.id).first
+    if card.blank?
+    else
+      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+      customer = Payjp::Customer.retrieve(card.customer_id)
+      customer.delete
+      card.delete
+    end
+      redirect_to action: "new"
+  end
+
+  def show 
+    card = Card.where(user_id: current_user.id).first
+    if card.blank?
+      redirect_to action: "new" 
+    else
+      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+      customer = Payjp::Customer.retrieve(card.customer_id)
+      @default_card_information = customer.cards.retrieve(card.card_id)
+    end
+  end
+
+end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -46,7 +46,7 @@ class ItemsController < ApplicationController
   end
 
   def show
-#    @order = Item.find(params[:id])
+    @order = Item.find(params[:id])
   end
 
   def edit

--- a/app/views/card/new.html.haml
+++ b/app/views/card/new.html.haml
@@ -1,0 +1,56 @@
+.account-page
+  .account-page__header
+    .account-page__header__box
+      =link_to '/'do
+        =image_tag 'logo.png', height: '50px'
+        
+.card-info
+  .card-info__main
+    %section.card-info__main__container
+      %h2 クレジットカード情報登録
+      .card-info__main__container__inner
+        %section
+          = form_tag(pay_card_index_path, method: :post, id: 'charge-form',  name: "inputForm") do
+            %label カード番号
+            = text_field_tag "number", "", class: "number", placeholder: "半角数字のみ" ,maxlength: "16", type: "text", id: "card_number"
+            %br
+            %label 有効期限(月)
+            %select#exp_month{name: "exp_month", type: "text"}
+              %option{value: ""} --
+              %option{value: "1"}01
+              %option{value: "2"}02
+              %option{value: "3"}03
+              %option{value: "4"}04
+              %option{value: "5"}05
+              %option{value: "6"}06
+              %option{value: "7"}07
+              %option{value: "8"}08
+              %option{value: "9"}09
+              %option{value: "10"}10
+              %option{value: "11"}11
+              %option{value: "12"}12
+            
+            %br
+            %label 有効期限(年)
+            %select#exp_year{name: "exp_year", type: "text"}
+              %option{value: ""} --
+              %option{value: "2019"}19
+              %option{value: "2020"}20
+              %option{value: "2021"}21
+              %option{value: "2022"}22
+              %option{value: "2023"}23
+              %option{value: "2024"}24
+              %option{value: "2025"}25
+              %option{value: "2026"}26
+              %option{value: "2027"}27
+              %option{value: "2028"}28
+              %option{value: "2029"}29
+            
+            %br
+            %label セキュリティコード
+            = text_field_tag "cvc", "", class: "cvc", placeholder: "カード背面3~4桁の番号", maxlength: "4", id: "cvc"
+            #card_token
+            = submit_tag "追加する", id: "token_submit"
+            
+  #card_token
+  .account-page__footer

--- a/app/views/card/show.html.haml
+++ b/app/views/card/show.html.haml
@@ -1,0 +1,97 @@
+= render 'items/index_header'
+
+- breadcrumb :card_info
+= render "layouts/breadcrumbs"
+.user-container
+  .user-container-contents
+    .user-container-contents__left
+      %ul.mypage-nav-list
+        %li
+          = link_to user_path(@current_user), class: "mypage-nav-list__link" do
+            マイページ
+        %li
+          = link_to user_path(@current_user), class: "mypage-nav-list__link" do
+            お知らせ
+        %li
+          = link_to user_path(@current_user), class: "mypage-nav-list__link" do
+            やることリスト
+        %li
+          = link_to user_path(@current_user), class: "mypage-nav-list__link" do
+            いいね！一覧
+        %li
+          = link_to user_path(@current_user), class: "mypage-nav-list__link" do
+            出品する
+        %li
+          = link_to user_path(@current_user), class: "mypage-nav-list__link" do
+            下書き一覧
+        %li
+          = link_to user_path(@current_user), class: "mypage-nav-list__link" do
+            出品した商品 - 出品中
+        %li
+          = link_to user_path(@current_user), class: "mypage-nav-list__link" do
+            出品した商品 - 取引中
+        %li
+          = link_to user_path(@current_user), class: "mypage-nav-list__link" do
+            出品した商品 - 売却済み
+        %li
+          = link_to user_path(@current_user), class: "mypage-nav-list__link" do
+            購入した商品 - 取引中
+        %li
+          = link_to user_path(@current_user), class: "mypage-nav-list__link" do
+            購入した商品 - 過去の取引
+        %li
+          = link_to user_path(@current_user), class: "mypage-nav-list__link" do
+            ニュース一覧
+        %li
+          = link_to user_path(@current_user), class: "mypage-nav-list__link" do
+            評価一覧
+        %li
+          = link_to user_path(@current_user), class: "mypage-nav-list__link" do
+            ガイド
+        %li
+          = link_to user_path(@current_user), class: "mypage-nav-list__link" do
+            お問い合わせ
+      %h3.mypage-nav-head
+        設定
+
+      %ul.mypage-nav-list
+        %li
+          = link_to user_path(@current_user), class: "mypage-nav-list__link" do
+            プロフィール
+        %li
+          = link_to user_path(@current_user), class: "mypage-nav-list__link" do
+            発送元・お届け先住所変更
+        %li
+          = link_to card_index_path, class: "mypage-nav-list__link" do
+            支払い方法
+        %li
+          = link_to user_path(@current_user), class: "mypage-nav-list__link" do
+            メール/パスワード
+        %li
+          = link_to user_path(@current_user), class: "mypage-nav-list__link" do
+            本人情報
+        %li
+          = link_to user_path(@current_user), class: "mypage-nav-list__link" do
+            電話番号の確認
+        %li
+          = link_to destroy_user_session_path, method: :delete, class: "mypage-nav-list__link" do
+            ログアウト
+    .card-info2
+      .card-info__main
+        %section.card-info__main__container
+          %h2 登録クレジットカード情報
+          .card-info__main__container__inner
+            %section
+              %ul
+                %li
+                  = "**** **** **** " + @default_card_information.last4
+                  %br
+                  - exp_month = @default_card_information.exp_month.to_s
+                  - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
+                  = exp_month + " / " + exp_year
+                  = form_tag(delete_card_index_path, method: :post, id: 'charge-form',  name: "inputForm", class: "delete-Btn") do
+                    %input{ type: "hidden", name: "card_id", value: "" }
+                    %button 削除する
+
+
+.account-page__footer

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -29,7 +29,7 @@
             %p or
             %a#modal-open.item-box__item-delete-btn この商品を削除する
           - else 
-//            =link_to item_index_path(@order), class:'item-box__order-btn' do
+            =link_to item_orders_path(@order), class:'item-box__order-btn' do
               購入画面に進む
       -else
         %p.item-box__sold-tag 売り切れました

--- a/app/views/orders/done.html.haml
+++ b/app/views/orders/done.html.haml
@@ -1,0 +1,14 @@
+.account-page
+  .account-page__header
+    .account-page__header__box
+      =link_to '/hogehoge'do
+        =image_tag 'logo.png', height: '50px'
+
+
+  .account-page__signup
+    %h2 商品の購入が完了しました
+    %br
+    = link_to root_path, class: "account-page__signup__done" do
+      トップページに戻る
+
+  .account-page__footer

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,11 +25,11 @@ Rails.application.routes.draw do
   end
 
 
-#  resources :card, only: [:new, :show] do
-#    collection do
-#      post 'show', to: 'card#show'
-#      post 'pay', to: 'card#pay'
-#      post 'delete', to: 'card#delete'
-#    end
-#  end
+  resources :card, only: [:new, :show] do
+    collection do
+      post 'show', to: 'card#show'
+      post 'pay', to: 'card#pay'
+      post 'delete', to: 'card#delete'
+    end
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -74,14 +74,22 @@ ActiveRecord::Schema.define(version: 2020_05_21_020420) do
     t.integer "shipping_fee_id", null: false
     t.integer "shipping_day_id", null: false
     t.integer "prefecture_id", null: false
-    t.string "brand"
     t.date "sold_day"
     t.bigint "user_id", null: false
     t.bigint "category_id", null: false
     t.bigint "item_size_id"
+    t.string "brand"
     t.index ["category_id"], name: "index_items_on_category_id"
     t.index ["item_size_id"], name: "index_items_on_item_size_id"
     t.index ["user_id"], name: "index_items_on_user_id"
+  end
+
+  create_table "pays", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "user_id"
+    t.string "customer_id", null: false
+    t.string "card_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
#what
最終課題アプリFURIMAにおけるクレジットカード情報の登録機能と購入機能の実装
app/contorollersorders_controller.rbで購入機能の実装をしています。

app/contorollers/cards_controller.rbでカード情報の登録/確認ができ、マイページのリンクから編集可能
マイページ画面
https://gyazo.com/18c5ae9fb9fa188f9b0b9549162f584c
cardsテーブル(Sequel Pro)
https://gyazo.com/a7b69227fb58d2920b0f35eb3279b31a

商品詳細ページから購入画面に移動する。その際にクレジットカード情報がユーザidに紐づいていない(登録されていない)場合はカード情報登録画面にリダイレクトする

購入が完了したら購入完了画面に遷移し、itemsテーブルのsold_dayカラムに日付が入る。これにより商品一覧画面に該当の商品は表示されなくなる。
購入完了画面
https://gyazo.com/f9723d67947f02da9947bcf926462fd9
購入完了後のitemsテーブル
https://gyazo.com/f8c96b197c84047f9938ed06879b2e94

同時にpay.jpで登録したアカウントに売り上げが計上される。
pay.jp画面
https://gyazo.com/b42429a3f7b93a1e73d6503ec276f489

#why
メンターさんへのコードレビュー依頼のため
